### PR TITLE
Add support for MD5 and SHA1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmemhash"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 
 [dependencies]
 clap = { version = "4.5.20", features = ["cargo", "wrap_help", "derive"] }
+digest = "0.10.7"
 infer = "0.16.0"
 rpassword = "7.3.1"
 sevenz-rust = { version = "0.6.1", features = ["aes256"] }
+sha1 = "0.10.6"
 sha2 = "0.10.8"
 tabular = "0.2.0"
 zip = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 clap = { version = "4.5.20", features = ["cargo", "wrap_help", "derive"] }
 digest = "0.10.7"
 infer = "0.16.0"
+md-5 = "0.10.6"
 rpassword = "7.3.1"
 sevenz-rust = { version = "0.6.1", features = ["aes256"] }
 sha1 = "0.10.6"

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -2,5 +2,6 @@ use clap::ValueEnum;
 
 #[derive(ValueEnum, Clone)]
 pub enum HashAlgo {
+    Sha1,
     Sha256,
 }

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -2,6 +2,7 @@ use clap::ValueEnum;
 
 #[derive(ValueEnum, Clone)]
 pub enum HashAlgo {
+    Md5,
     Sha1,
     Sha256,
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,15 +1,26 @@
 use super::algo::HashAlgo;
 use super::archive::EnclosedFile;
-use sha2::{Digest, Sha256};
+use digest::Digest;
+use sha1::Sha1;
+use sha2::Sha256;
 
-fn get_hash_from_data(data: &Vec<u8>, algo: &HashAlgo) -> String {
-    let mut hasher = match algo {
-        HashAlgo::Sha256 => Sha256::new(),
-    };
-
+// https://stackoverflow.com/q/64326373/
+fn compute_hash<D: Digest>(data: &Vec<u8>) -> String
+where
+    D::OutputSize: std::ops::Add,
+    <D::OutputSize as std::ops::Add>::Output: digest::generic_array::ArrayLength<u8>,
+{
+    let mut hasher = D::new();
     hasher.update(data);
     let hash = hasher.finalize();
     format!("{:x}", hash)
+}
+
+fn get_hash_from_data(data: &Vec<u8>, algo: &HashAlgo) -> String {
+    match algo {
+        HashAlgo::Sha1 => compute_hash::<Sha1>(data),
+        HashAlgo::Sha256 => compute_hash::<Sha256>(data),
+    }
 }
 
 pub fn get_hash_from_enclosed_file(file: &EnclosedFile, algo: &HashAlgo) -> String {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,6 +1,7 @@
 use super::algo::HashAlgo;
 use super::archive::EnclosedFile;
 use digest::Digest;
+use md5::Md5;
 use sha1::Sha1;
 use sha2::Sha256;
 
@@ -18,6 +19,7 @@ where
 
 fn get_hash_from_data(data: &Vec<u8>, algo: &HashAlgo) -> String {
     match algo {
+        HashAlgo::Md5 => compute_hash::<Md5>(data),
         HashAlgo::Sha1 => compute_hash::<Sha1>(data),
         HashAlgo::Sha256 => compute_hash::<Sha256>(data),
     }

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -9,10 +9,11 @@
 # Run via:
 #   $ ./build.sh && ./tests/e2e.sh || rm test-xmemhash.*
 
-set -xe
+# set -xe
 trap 'exit 1' INT
 
 FILE="test-xmemhash.txt"
+HASH="${1:-sha256}"
 
 if [ -e "$FILE" ]; then
     echo "Cannot test on '$FILE' as it already exists"
@@ -32,12 +33,13 @@ zip -P infected "$FILE_ZIP_P" "$FILE" > /dev/null
 7z a "$FILE_7Z" "$FILE" > /dev/null
 7z a -pinfected "$FILE_7Z_P" "$FILE" > /dev/null
 
+sha1sum "$FILE"
 sha256sum "$FILE"
 
-./xmemhash "$FILE_ZIP"
-./xmemhash "$FILE_ZIP_P"
-./xmemhash "$FILE_7Z"
-./xmemhash "$FILE_7Z_P"
+./xmemhash --hash "$HASH" "$FILE_ZIP"
+./xmemhash --hash "$HASH" "$FILE_ZIP_P"
+./xmemhash --hash "$HASH" "$FILE_7Z"
+./xmemhash --hash "$HASH" "$FILE_7Z_P"
 
 rm "$FILE"
 rm "$FILE_ZIP"

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -33,8 +33,9 @@ zip -P infected "$FILE_ZIP_P" "$FILE" > /dev/null
 7z a "$FILE_7Z" "$FILE" > /dev/null
 7z a -pinfected "$FILE_7Z_P" "$FILE" > /dev/null
 
-sha1sum "$FILE"
-sha256sum "$FILE"
+echo -n "MD5:    "; md5sum "$FILE"
+echo -n "SHA1:   "; sha1sum "$FILE"
+echo -n "SHA256: "; sha256sum "$FILE"
 
 ./xmemhash --hash "$HASH" "$FILE_ZIP"
 ./xmemhash --hash "$HASH" "$FILE_ZIP_P"


### PR DESCRIPTION
While they are cryptographically "mid," they are still widely used for file indicators, so I figured I'd add support for them