### PR TITLE
Improve file parsing error logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "serde"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +828,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1189,6 +1217,7 @@ dependencies = [
  "sevenz-rust",
  "sha1",
  "sha2",
+ "strum",
  "tabular",
  "tar",
  "zip",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ dependencies = [
 
 [[package]]
 name = "xmemhash"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "clap",
  "digest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmemhash"
-version = "1.4.1"
+version = "1.4.2"
 edition = "2021"
 authors = ["Jake W. Ireland <jakewilliami@icloud.com>"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rpassword = "7.3.1"
 sevenz-rust = { version = "0.6.1", features = ["aes256"] }
 sha1 = "0.10.6"
 sha2 = "0.10.8"
+strum = { version = "0.26.3", features = ["derive"] }
 tabular = "0.2.0"
 tar = "0.4.42"
 zip = "2.2.0"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -4,7 +4,9 @@
 
 use super::decompress::{gzip, sevenzip, tar, zip};
 use std::{path::PathBuf, str::FromStr};
+use strum::EnumIter;
 
+#[derive(EnumIter)]
 pub enum ArchiveType {
     Zip,
     SevenZip,
@@ -40,6 +42,17 @@ impl FromStr for ArchiveType {
             "application/x-tar" => Ok(ArchiveType::Tar),
             _ => Err(()),
         }
+    }
+}
+
+impl From<ArchiveType> for String {
+    fn from(archive_type: ArchiveType) -> Self {
+        String::from(match archive_type {
+            ArchiveType::Zip => "zip",
+            ArchiveType::SevenZip => "7zip",
+            ArchiveType::Gzip => "gzip",
+            ArchiveType::Tar => "tar",
+        })
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -9,6 +9,7 @@ use std::{
     path::Path,
     str::FromStr,
 };
+use strum::IntoEnumIterator;
 
 struct PathValid {
     is_valid: bool,
@@ -49,9 +50,14 @@ impl From<&String> for PathValid {
                 if ArchiveType::from_str(kind.mime_type()).is_ok() {
                     PathValid::valid()
                 } else {
+                    let supported_archive_types = ArchiveType::iter()
+                        .map(String::from)
+                        .collect::<Vec<_>>()
+                        .join(", ");
                     PathValid::invalid(&format!(
-                        "unsupported archive type \"{}\"",
-                        kind.mime_type()
+                        "unsupported archive type \"{}\"; supported types: {}",
+                        kind.mime_type(),
+                        supported_archive_types,
                     ))
                 }
             } else {

--- a/src/file.rs
+++ b/src/file.rs
@@ -44,10 +44,13 @@ impl From<&String> for PathValid {
                 if ArchiveType::from_str(kind.mime_type()).is_ok() {
                     PathValid::valid()
                 } else {
-                    PathValid::invalid("unsupported archive type")
+                    PathValid::invalid(&format!(
+                        "unsupported archive type \"{}\"",
+                        kind.mime_type()
+                    ))
                 }
             } else {
-                PathValid::invalid("file is not a valid archive")
+                PathValid::invalid(&format!("invalid file type \"{}\"", kind.mime_type()))
             }
         } else {
             // Cannot get file type, so we must assume the input was not an archive


### PR DESCRIPTION
Currently, if you provide the program with an invalid file, it will state that it is invalid either
  - because we can't figure out what kind of file it is (i.e., no header information);
  - because it is not an archive file; or
  - because it is not a _supported_ archive file.

It would be good to improve the error messages, to explain what files are supported, and give a bit more information about what file was provided, so that the user can better understand why it is erroneous.